### PR TITLE
Make qChecksum call compatible with QT 5.15 and QT 6

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -29,6 +29,7 @@
 #include <QJsonDocument>
 #include <QMessageBox>
 #include <QInputDialog>
+#include <QByteArray>
 
 #include <chrono>
 #include <thread>
@@ -464,7 +465,12 @@ void MainWindow::on_pushButtonEncodeAndSign_clicked()
 
 static inline int jwtAlgoFromString(const QString alg)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
     const uint16_t crc16 = qChecksum(QByteArrayView(alg.toUtf8()));
+#else
+    QByteArray ba = alg.toUtf8();
+    const uint16_t crc16 = qChecksum(ba.constData(),ba.length());
+#endif
 
     switch (crc16)
     {


### PR DESCRIPTION
#include for QByteArray probably isn't needed, but should do no harm. Remnant from debugging the issue

Despite QT not saying when the qChecksum parameters changed, my best guess is between Qt 5.15 and 6.0.0, but as it is undocumented I'm not 100% sure on the best version to use in the QT_VERSION_CHECK